### PR TITLE
Fix stellar config on the base image

### DIFF
--- a/testnet/core/etc/stellar-core.cfg
+++ b/testnet/core/etc/stellar-core.cfg
@@ -1,15 +1,18 @@
-#todo: quorum with 1 of 3.
-#todo: private keys for nodes.
-#NAME="pi_testnet_1"
+# Stellar config
+# v0.0.6 / base image
+# Created on 2021-01-25
 
-HTTP_PORT=31402
-PUBLIC_HTTP_PORT=true
+HTTP_PORT=11626
+PUBLIC_HTTP_PORT=false
 LOG_FILE_PATH=""
 
 NETWORK_PASSPHRASE="Pi Testnet ; June 2020"
-CATCHUP_COMPLETE=true
+CATCHUP_COMPLETE=false
+CATCHUP_RECENT=256
+
 DATABASE="postgresql://dbname=core host=localhost user=stellar password=__PGPASS__"
-CATCHUP_RECENT=100
+
+PEER_PORT=31402
 
 # PREFERRED_PEERS (list of strings) default is empty
 # These are IP:port strings that this server will add to its DB of peers.
@@ -41,9 +44,7 @@ KNOWN_PEERS=["testnet1.minepi.com:31402", "testnet2.minepi.com:31402", "testnet3
 # Set of cursors added at each startup with value '1'.
 KNOWN_CURSORS=["HORIZON"]
 
-# Below is an example of public-private key pair. Replace it with your own and don't use it in production.
-# Secret seed: SBXHVERXGL76IQXQUK5Q74U6JLVIAOJDAHIYHC6KZQSW4TMGCO63S4BV
-# Public: GBZZZVLOLYMDEAGQ62QKDNXINSUKNR67H4QLHIMW7RH7CLF6OCANGC3E
+# NODE SEED & NODE VALIDATOR
 NODE_SEED="__NODE_PRIVATE_KEY__ self"
 
 # NODE_IS_VALIDATOR (boolean) default false.
@@ -52,8 +53,8 @@ NODE_SEED="__NODE_PRIVATE_KEY__ self"
 # See QUORUM_SET below.
 NODE_IS_VALIDATOR=false
 
-
 UNSAFE_QUORUM=true
+
 [QUORUM_SET]
 THRESHOLD_PERCENT=32  # 32% - one of three validators of the testnet is consudered enough.
 VALIDATORS=[
@@ -64,9 +65,3 @@ VALIDATORS=[
 
 [HISTORY.cache]
 get="curl -sf https://history.testnet.minepi.com/{0} -o {1}"
-
-# todo: add a local archive
-# [HISTORY.vs]
-# get="cp /tmp/stellar-core/history/vs/{0} {1}"
-# put="cp {0} /tmp/stellar-core/history/vs/{1}"
-# mkdir="mkdir -p /tmp/stellar-core/history/vs/{0}"


### PR DESCRIPTION
This PR updates the config on the base image with the following settings:

```
HTTP_PORT=11626
PUBLIC_HTTP_PORT=false
PEER_PORT=31402
CATCHUP_COMPLETE=false
CATCHUP_RECENT=256
```