### PR TITLE
[PI-1369] Don't start horizon by default

### DIFF
--- a/common/supervisor/etc/supervisord.conf
+++ b/common/supervisor/etc/supervisord.conf
@@ -17,8 +17,7 @@ serverurl=unix:///var/run/supervisor.sock
 user=postgres
 command=/usr/lib/postgresql/9.5/bin/postgres -D "/opt/stellar/postgresql/data" -c config_file=/opt/stellar/postgresql/etc/postgresql.conf
 stopsignal=INT
-autostart=true
-autorestart=true
+autostart=false
 priority=10
 
 [program:stellar-core]


### PR DESCRIPTION
# Don't start horizon by default

Second attempt of https://github.com/PiCoreTeam/pi-node-docker/pull/4
