### PR TITLE
[PI-1458] Stop horizon and start postgres

### DIFF
--- a/common/supervisor/etc/supervisord.conf
+++ b/common/supervisor/etc/supervisord.conf
@@ -17,7 +17,8 @@ serverurl=unix:///var/run/supervisor.sock
 user=postgres
 command=/usr/lib/postgresql/9.5/bin/postgres -D "/opt/stellar/postgresql/data" -c config_file=/opt/stellar/postgresql/etc/postgresql.conf
 stopsignal=INT
-autostart=false
+autostart=true
+autorestart=true
 priority=10
 
 [program:stellar-core]
@@ -32,8 +33,7 @@ priority=20
 user=stellar
 directory=/opt/stellar/horizon
 command=/opt/stellar/horizon/bin/start
-autostart=true
-autorestart=true
+autostart=false
 priority=30
 # No idea why Horizon stdout goes to stderr log in supervisor... This is the
 # easiest fix.


### PR DESCRIPTION
# Stop horizon and start postgres

The change in https://github.com/PiCoreTeam/pi-node-docker/pull/5 mistakenly changed Postgres to not start or restart by default. We need to correct this, and also stop Horizon by default, as the PR was meaning to do.