### PR TITLE
Watcher Node (Deprecated)

### DIFF
--- a/testnet2/core/etc/stellar-core.cfg
+++ b/testnet2/core/etc/stellar-core.cfg
@@ -1,4 +1,4 @@
-# Pi Testnet2 - Watcher node (default configuration)
+# Pi Testnet2 - Basic Validator node (default configuration)
 # 0.0.1
 
 PUBLIC_HTTP_PORT = false
@@ -23,7 +23,6 @@ PREFERRED_PEER_KEYS = [
 PREFERRED_PEERS_ONLY = false
 
 NODE_SEED = "__NODE_PRIVATE_KEY__"
-NODE_IS_VALIDATOR = false
 
 UNSAFE_QUORUM = false
 FAILURE_SAFETY = -1


### PR DESCRIPTION
Due to watcher node is deprecated after Horizon 2.0 which will optimized the performance. Change Watcher Node to Basic Validator Node
Mention: Node_Seed is unnecessary when node is not a validator.