### PR TITLE
Ensure Postgres Started before migration

### DIFF
--- a/start
+++ b/start
@@ -35,6 +35,7 @@ function main() {
 	init_horizon
 	copy_pgpass
 
+    stop_postgres
 	# run migrations if enabled (postgres is still running here)
 	run_migrations
 


### PR DESCRIPTION
During upgrade from 19.1 to 19.6. The following error shown
```
Attaching to mainnet
mainnet    | 
mainnet    | Starting Pi Node
mainnet    | 
mainnet    | mode: persistent
mainnet    | network: pubnet (Pi Network)
mainnet    | postgres: config directory exists, skipping copy
mainnet    | supervisor: config directory exists, skipping copy
mainnet    | stellar-core: config directory exists, skipping copy
mainnet    | horizon: config directory exists, skipping copy
mainnet    | postgres: already initialized
mainnet    | chown-core: ok
mainnet    | core: already initialized
mainnet    | horizon: already initialized
mainnet    | running migrations...
mainnet    | 2026-02-09 04:02:54 [MIGRATION] [INFO] ==========================================
mainnet    | 2026-02-09 04:02:54 [MIGRATION] [INFO] Starting Migration Runner
mainnet    | 2026-02-09 04:02:54 [MIGRATION] [INFO] ==========================================
mainnet    | 2026-02-09 04:02:54 [MIGRATION] [INFO] Migrations directory: /migrations
mainnet    | 2026-02-09 04:02:54 [MIGRATION] [INFO] Status file: /opt/stellar/migration_status
mainnet    | 2026-02-09 04:02:54 [MIGRATION] [INFO] Initializing migration status file: /opt/stellar/migration_status
mainnet    | 2026-02-09 04:02:54 [MIGRATION] [OK] Migration status file created
mainnet    | 2026-02-09 04:02:54 [MIGRATION] [INFO] Backup directory created: /opt/stellar/migration_backups/20260209_040254
mainnet    | 2026-02-09 04:02:54 [MIGRATION] [INFO] Executing migration: 001_update_validator3.sh
mainnet    | 2026-02-09 04:02:54 [001] [INFO]  Starting migration: Update validator3
mainnet    | 2026-02-09 04:02:54 [001] [INFO]  Running on mainnet (Pi Network)
mainnet    | 2026-02-09 04:02:54 [001] [INFO]  Backup created: /opt/stellar/migration_backups/20260209_040254/stellar-core.cfg.20260209_040254
mainnet    | 2026-02-09 04:02:54 [001] [INFO]  Updating validator3 section...
mainnet    | 2026-02-09 04:02:54 [001] [OK]    Validator3 section updated
mainnet    | 2026-02-09 04:02:54 [001] [INFO]  Adding validator3 to PREFERRED_PEER_KEYS...
mainnet    | 2026-02-09 04:02:54 [001] [OK]    Validator3 added to PREFERRED_PEER_KEYS
mainnet    | 2026-02-09 04:02:54 [001] [INFO]  Updating validator1 HISTORY to CDN...
mainnet    | 2026-02-09 04:02:54 [001] [OK]    Validator1 HISTORY updated
mainnet    | 2026-02-09 04:02:54 [001] [INFO]  Updating validator2 HISTORY to CDN...
mainnet    | 2026-02-09 04:02:54 [001] [OK]    Validator2 HISTORY updated
mainnet    | 2026-02-09 04:02:54 [001] [INFO]  Running Horizon database migration...
mainnet    | ping failed: failed to connect to DB after 30 attempts: dial tcp 127.0.0.1:5432: connect: connection refused
mainnet    | 2026-02-09 04:03:24 [001] [ERROR] Horizon migration failed
mainnet    | 2026-02-09 04:03:24 [MIGRATION] [ERROR] Migration failed: 001_update_validator3.sh
mainnet    | 2026-02-09 04:03:24 [MIGRATION] [ERROR] Aborting migration process due to failure
mainnet exited with code 1
```
It is because both postgres, core and horizon is already initialized. Thus causing `start_postgres` is not called before `run_migrations`